### PR TITLE
Show life increment on the side opposite the tapped side

### DIFF
--- a/lib/widgets/arena/player_cell/arena_player_cell.dart
+++ b/lib/widgets/arena/player_cell/arena_player_cell.dart
@@ -54,6 +54,9 @@ class _ArenaPlayerCellState extends State<_ArenaPlayerCell>
   @override
   Reactive<int> increment = Reactive(0);
 
+  @override
+  Reactive<bool> incrementOnRight = Reactive(true);
+
   /// whether the advanced options are shown (commander casts, counters)
   @override
   Reactive<bool> advanced = Reactive(false);
@@ -64,6 +67,7 @@ class _ArenaPlayerCellState extends State<_ArenaPlayerCell>
   @override
   void dispose() {
     increment.dispose();
+    incrementOnRight.dispose();
     advanced.dispose();
     cachedAttackerIndex.dispose();
     super.dispose();
@@ -138,6 +142,8 @@ class _ArenaPlayerCellState extends State<_ArenaPlayerCell>
 
 mixin ArenaPlayerController {
   Reactive<int> get increment;
+
+  Reactive<bool> get incrementOnRight;
 
   Reactive<bool> get advanced;
 

--- a/lib/widgets/arena/player_cell/components/player_cell_center.dart
+++ b/lib/widgets/arena/player_cell/components/player_cell_center.dart
@@ -45,8 +45,9 @@ class PlayerCellCenter extends StatelessWidget {
           ),
         );
 
-        return Row(
+        return controller.incrementOnRight.build((context, onRight) => Row(
           mainAxisSize: MainAxisSize.min,
+          textDirection: onRight ? TextDirection.ltr : TextDirection.rtl,
           children: [
             ArenaCellModeBuilder(
               playerIndex: playerIndex,
@@ -81,7 +82,8 @@ class PlayerCellCenter extends StatelessWidget {
                 listed: value != 0,
                 direction: Axis.horizontal,
                 child: Pad(
-                  left: theme.layout.padding.medium,
+                  left: onRight ? theme.layout.padding.medium : 0,
+                  right: onRight ? 0 : theme.layout.padding.medium,
                   child: Row(
                     children: [
                       Text(value >= 0 ? '+' : '-', style: incrementStyle),
@@ -93,7 +95,7 @@ class PlayerCellCenter extends StatelessWidget {
               ),
             ),
           ],
-        );
+        ));
       },
     );
   }

--- a/lib/widgets/arena/player_cell/components/player_cell_side_taps.dart
+++ b/lib/widgets/arena/player_cell/components/player_cell_side_taps.dart
@@ -71,6 +71,13 @@ class PlayerCellSideTaps extends StatelessWidget {
       context,
       direction,
     ) {
+      void setSide(TapDownDetails details, double width, {required bool firstRegion}) {
+        final bool tappedLeft = direction == Axis.horizontal
+            ? firstRegion
+            : details.localPosition.dx < width / 2;
+        controller.incrementOnRight.update(tappedLeft);
+      }
+
       return Stack(
         children: [
           Positioned.fill(
@@ -81,23 +88,39 @@ class PlayerCellSideTaps extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
                   Expanded(
-                    child: ContinuedLongPress(
-                      onContinuedLongPress: (duration) =>
-                          onLongPress(duration, direction),
-                      onTapDown: direction == Axis.horizontal
-                          ? holdDown
-                          : holdUp,
-                      onTapUp: delay.tap,
+                    child: LayoutBuilder(
+                      builder: (context, constraints) => ContinuedLongPress(
+                        onContinuedLongPress: (duration) =>
+                            onLongPress(duration, direction),
+                        onTapDown: (details) {
+                          setSide(details, constraints.maxWidth,
+                              firstRegion: true);
+                          if (direction == Axis.horizontal) {
+                            holdDown();
+                          } else {
+                            holdUp();
+                          }
+                        },
+                        onTapUp: delay.tap,
+                      ),
                     ),
                   ),
                   Expanded(
-                    child: ContinuedLongPress(
-                      onContinuedLongPress: (duration) =>
-                          onLongPress(duration, direction.opposite),
-                      onTapDown: direction == Axis.horizontal
-                          ? holdUp
-                          : holdDown,
-                      onTapUp: delay.tap,
+                    child: LayoutBuilder(
+                      builder: (context, constraints) => ContinuedLongPress(
+                        onContinuedLongPress: (duration) =>
+                            onLongPress(duration, direction.opposite),
+                        onTapDown: (details) {
+                          setSide(details, constraints.maxWidth,
+                              firstRegion: false);
+                          if (direction == Axis.horizontal) {
+                            holdUp();
+                          } else {
+                            holdDown();
+                          }
+                        },
+                        onTapUp: delay.tap,
+                      ),
                     ),
                   ),
                 ],
@@ -128,7 +151,7 @@ class ContinuedLongPress extends StatefulWidget {
   });
 
   final Widget? child;
-  final VoidCallback onTapDown;
+  final void Function(TapDownDetails details) onTapDown;
   final VoidCallback onTapUp;
   final void Function(Duration duration) onContinuedLongPress;
 
@@ -187,7 +210,7 @@ class _ContinuedLongPressState extends State<ContinuedLongPress> {
   Widget build(BuildContext context) {
     return InkWell(
       onTapDown: (details) {
-        widget.onTapDown();
+        widget.onTapDown(details);
         onTapDown();
       },
       onTapUp: (details) => onTapUp(),


### PR DESCRIPTION
Tapping the left half of an `ArenaPlayerCell` now displays the pending life increment to the right of the life total, and tapping the right half displays it to the left, the increment lands opposite the side you touched.

Works in both arena orientations:
- Horizontal: the tapped region (left/right half) determines the side.
- Vertical: the tap's horizontal position within the full-width region is used.

Implementation:
- Added `incrementOnRight` reactive to `ArenaPlayerController`.
- `PlayerCellSideTaps` records the tapped side on tap-down (plumbing `TapDownDetails` through `ContinuedLongPress`).
- `PlayerCellCenter` orders the row via `textDirection` so the existing life-total widget is untouched.
